### PR TITLE
Add button configuration for BLE_Button application.

### DIFF
--- a/BLE_Button/mbed_app.json
+++ b/BLE_Button/mbed_app.json
@@ -1,13 +1,28 @@
 {
+    "config": {
+        "ble_button_pin_name": {
+            "help": "The pin name used as button in this application",
+            "macro_name": "BLE_BUTTON_PIN_NAME",
+            "required": true
+        }
+    },
     "target_overrides": {
+        "NRF51_DK": {
+            "ble_button_pin_name": "BUTTON1"
+        },
+        "NRF52_DK": {
+            "ble_button_pin_name": "BUTTON1"
+        },
         "K64F": {
             "target.features_add": ["BLE"],
             "target.extra_labels_add": ["ST_BLUENRG"],
-            "target.macros_add": ["IDB0XA1_D13_PATCH"]
+            "target.macros_add": ["IDB0XA1_D13_PATCH"],
+            "ble_button_pin_name": "SW2"
         },
         "NUCLEO_F401RE": {
             "target.features_add": ["BLE"],
-            "target.extra_labels_add": ["ST_BLUENRG"]
+            "target.extra_labels_add": ["ST_BLUENRG"],
+            "ble_button_pin_name": "USER_BUTTON"
         }
     }
 }

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -21,7 +21,7 @@
 #include "ButtonService.h"
 
 DigitalOut  led1(LED1, 1);
-InterruptIn button(BUTTON1);
+InterruptIn button(BLE_BUTTON_PIN_NAME);
 
 static EventQueue eventQueue(
     /* event count */ 10 * /* event size */ 32


### PR DESCRIPTION
This should fix https://github.com/ARMmbed/mbed-os-example-ble/issues/10 .
The pin name was only valid for NRF based targets.
