### PR TITLE
Update BLE_HeartRate to use mbed-events v0.5

### DIFF
--- a/BLE_HeartRate/mbed-events.lib
+++ b/BLE_HeartRate/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97


### PR DESCRIPTION
Ran into a problem in a project of my own when trying to use these BLE examples with code from the [mbed-events](https://github.com/ARMmbed/mbed-events) v0.5 tag.

Updated the Heart Rate Monitor example to use the [mbed-events](https://github.com/ARMmbed/mbed-events) v0.5 API.