### PR TITLE
Update all examples to mbed-events API v0.5.

### DIFF
--- a/BLE_BatteryLevel/mbed-events.lib
+++ b/BLE_BatteryLevel/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_BatteryLevel/source/main.cpp
+++ b/BLE_BatteryLevel/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/Gap.h"

--- a/BLE_BatteryLevel/source/main.cpp
+++ b/BLE_BatteryLevel/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/Gap.h"
@@ -52,7 +52,7 @@ void blinkCallback(void)
 
     BLE &ble = BLE::Instance();
     if (ble.gap().getState().connected) {
-        eventQueue.post(updateSensorValue);
+        eventQueue.call(updateSensorValue);
     }
 }
 
@@ -99,12 +99,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
-    eventQueue.post_every(500, blinkCallback);
+    eventQueue.call_every(500, blinkCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_Beacon/mbed-events.lib
+++ b/BLE_Beacon/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/services/iBeacon.h"

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/services/iBeacon.h"
@@ -73,7 +73,7 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()

--- a/BLE_Button/mbed-events.lib
+++ b/BLE_Button/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 
 #include <mbed.h>
 #include "ble/BLE.h"

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 
 #include <mbed.h>
 #include "ble/BLE.h"
@@ -34,12 +34,12 @@ ButtonService *buttonServicePtr;
 
 void buttonPressedCallback(void)
 {
-    eventQueue.post(Callback<void(bool)>(buttonServicePtr, &ButtonService::updateButtonState), true);
+    eventQueue.call(Callback<void(bool)>(buttonServicePtr, &ButtonService::updateButtonState), true);
 }
 
 void buttonReleasedCallback(void)
 {
-    eventQueue.post(Callback<void(bool)>(buttonServicePtr, &ButtonService::updateButtonState), false);
+    eventQueue.call(Callback<void(bool)>(buttonServicePtr, &ButtonService::updateButtonState), false);
 }
 
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *params)
@@ -92,12 +92,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
-    eventQueue.post_every(500, blinkCallback);
+    eventQueue.call_every(500, blinkCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_EddystoneObserver/mbed-events.lib
+++ b/BLE_EddystoneObserver/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_EddystoneObserver/source/main.cpp
+++ b/BLE_EddystoneObserver/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include "mbed.h"
 #include "ble/BLE.h"
 

--- a/BLE_EddystoneObserver/source/main.cpp
+++ b/BLE_EddystoneObserver/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include "mbed.h"
 #include "ble/BLE.h"
 
@@ -145,12 +145,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
-    eventQueue.post_every(500, periodicCallback);
+    eventQueue.call_every(500, periodicCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_EddystoneService/mbed-events.lib
+++ b/BLE_EddystoneService/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 
 #include <mbed.h>
 #include "ble/BLE.h"
@@ -67,7 +67,7 @@ static void timeout(void)
         eddyServicePtr->getEddystoneParams(params);
         saveEddystoneServiceConfigParams(&params);
     } else {
-        eventQueue.post_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
+        eventQueue.call_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
     }
 }
 
@@ -116,12 +116,12 @@ static void bleInitComplete(BLE::InitializationCompleteCallbackContext* initCont
     /* Start Eddystone in config mode */
    eddyServicePtr->startConfigService();
 
-   eventQueue.post_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
+   eventQueue.call_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
 }
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 
@@ -132,7 +132,7 @@ int main()
     setbuf(stderr, NULL);
     setbuf(stdin, NULL);
 
-    eventQueue.post_every(500, blinky);
+    eventQueue.call_every(500, blinky);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 
 #include <mbed.h>
 #include "ble/BLE.h"

--- a/BLE_GAPButton/mbed-events.lib
+++ b/BLE_GAPButton/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_GAPButton/source/main.cpp
+++ b/BLE_GAPButton/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 
@@ -101,7 +101,7 @@ void buttonPressedCallback(void)
 
     // Calling BLE api in interrupt context may cause race conditions
     // Using mbed-events to schedule calls to BLE api for safety
-    eventQueue.post(updatePayload);
+    eventQueue.call(updatePayload);
 }
 
 void blinkCallback(void)
@@ -169,7 +169,7 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *context)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
@@ -185,7 +185,7 @@ int main()
     }
 
     // Blink LED every 500 ms to indicate system aliveness
-    eventQueue.post_every(500, blinkCallback);
+    eventQueue.call_every(500, blinkCallback);
 
     // Register function to be called when button is released
     button.rise(buttonPressedCallback);

--- a/BLE_GAPButton/source/main.cpp
+++ b/BLE_GAPButton/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 

--- a/BLE_HeartRate/mbed-events.lib
+++ b/BLE_HeartRate/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_HeartRate/source/main.cpp
+++ b/BLE_HeartRate/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/Gap.h"

--- a/BLE_HeartRate/source/main.cpp
+++ b/BLE_HeartRate/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/Gap.h"
@@ -55,7 +55,7 @@ void periodicCallback(void)
     led1 = !led1; /* Do blinky on LED1 while we're waiting for BLE events */
 
     if (BLE::Instance().getGapState().connected) {
-        eventQueue.post(updateSensorValue);
+        eventQueue.call(updateSensorValue);
     }
 }
 
@@ -97,12 +97,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
-    eventQueue.post_every(500, periodicCallback);
+    eventQueue.call_every(500, periodicCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_LED/mbed-events.lib
+++ b/BLE_LED/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_LED/source/main.cpp
+++ b/BLE_LED/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "LEDService.h"

--- a/BLE_LED/source/main.cpp
+++ b/BLE_LED/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "LEDService.h"
@@ -98,12 +98,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
-    eventQueue.post_every(500, blinkCallback);
+    eventQueue.call_every(500, blinkCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_LEDBlinker/mbed-events.lib
+++ b/BLE_LEDBlinker/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/DiscoveredCharacteristic.h"
@@ -95,7 +95,7 @@ void discoveryTerminationCallback(Gap::Handle_t connectionHandle) {
     printf("terminated SD for handle %u\r\n", connectionHandle);
     if (triggerLedCharacteristic) {
         triggerLedCharacteristic = false;
-        eventQueue.post(updateLedCharacteristic);
+        eventQueue.call(updateLedCharacteristic);
     }
 }
 
@@ -168,13 +168,13 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
     triggerLedCharacteristic = false;
-    eventQueue.post_every(500, periodicCallback);
+    eventQueue.call_every(500, periodicCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/DiscoveredCharacteristic.h"

--- a/BLE_Thermometer/mbed-events.lib
+++ b/BLE_Thermometer/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include "mbed.h"
 #include "ble/BLE.h"
 #include "ble/services/HealthThermometerService.h"
@@ -49,7 +49,7 @@ void periodicCallback(void)
     led1 = !led1; /* Do blinky on LED1 while we're waiting for BLE events */
 
     if (BLE::Instance().gap().getState().connected) {
-        eventQueue.post(updateSensorValue);
+        eventQueue.call(updateSensorValue);
     }
 }
 
@@ -89,12 +89,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
 {
-    eventQueue.post_every(500, periodicCallback);
+    eventQueue.call_every(500, periodicCallback);
 
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(scheduleBleEventsProcessing);

--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include "mbed.h"
 #include "ble/BLE.h"
 #include "ble/services/HealthThermometerService.h"

--- a/BLE_URIBeacon/mbed-events.lib
+++ b/BLE_URIBeacon/mbed-events.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-events.git#6be60bf880c11a0beafcc2064bf467f8d897529a
+https://github.com/ARMmbed/mbed-events/#17dfdd5ca9fcc615b56418124f7f4187b854aa97

--- a/BLE_URIBeacon/source/main.cpp
+++ b/BLE_URIBeacon/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/events.h>
+#include <mbed-events/mbed-events.h>
 #include "mbed.h"
 #include "ble/BLE.h"
 #include "ble/services/URIBeaconConfigService.h"
@@ -53,7 +53,7 @@ void timeout(void)
         uriBeaconConfig->setupURIBeaconAdvertisements();
         ble.startAdvertising();
     } else {
-        eventQueue.post_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
+        eventQueue.call_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
     }
 }
 
@@ -67,7 +67,7 @@ void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *)
 
 void scheduleBleEventsProcessing(BLE::OnEventsToProcessCallbackContext* context) {
     BLE &ble = BLE::Instance();
-    eventQueue.post(Callback<void()>(&ble, &BLE::processEvents));
+    eventQueue.call(Callback<void()>(&ble, &BLE::processEvents));
 }
 
 int main()
@@ -99,7 +99,7 @@ int main()
     ble.startAdvertising(); /* Set the whole thing in motion. After this call a GAP central can scan the URIBeaconConfig
                              * service. This can then be switched to the normal URIBeacon functionality after a timeout. */
 
-    eventQueue.post_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
+    eventQueue.call_in(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000, timeout);
 
     while (true) {
         eventQueue.dispatch();

--- a/BLE_URIBeacon/source/main.cpp
+++ b/BLE_URIBeacon/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <mbed-events/mbed-events.h>
+#include <mbed-events/mbed_events.h>
 #include "mbed.h"
 #include "ble/BLE.h"
 #include "ble/services/URIBeaconConfigService.h"


### PR DESCRIPTION
@pan- @nvlsianpu -- Ok, how about this, I updated mbed-events in BLE_BatteryLevel with `mbed update v0.5`.

Then:
`ls -d BLE* | xargs -n 1 cp BLE_BatteryLevel/mbed-events.lib -v`

Then:
`find . -type f -path "*/source/main.cpp" | xargs sed -i -e 's|events.h|mbed_events.h|g' -e 's|.post|.call|g'`