### PR TITLE
update mbed-os library to mbed-os-5.2.3

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_EddystoneObserver/mbed-os.lib
+++ b/BLE_EddystoneObserver/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_EddystoneObserver/mbed-os.lib
+++ b/BLE_EddystoneObserver/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_EddystoneObserver/mbed-os.lib
+++ b/BLE_EddystoneObserver/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_EddystoneService/mbed-os.lib
+++ b/BLE_EddystoneService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_EddystoneService/mbed-os.lib
+++ b/BLE_EddystoneService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_EddystoneService/mbed-os.lib
+++ b/BLE_EddystoneService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196

--- a/BLE_URIBeacon/mbed-os.lib
+++ b/BLE_URIBeacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51


### PR DESCRIPTION
This PR is to update mbed-os library to mbed-os-5.2.3. Before accepting please run suitable tests to ensure that this update is compatible with this example. Decline the PR if you do not wish to accept.
@pan- 