### PR TITLE
Fix#58: Inprove portability of BLE_URIBeacon

### DIFF
--- a/BLE_URIBeacon/source/main.cpp
+++ b/BLE_URIBeacon/source/main.cpp
@@ -18,7 +18,6 @@
 #include "mbed.h"
 #include "ble/BLE.h"
 #include "ble/services/URIBeaconConfigService.h"
-#include "ble/services/DFUService.h"
 #include "ble/services/DeviceInformationService.h"
 #include "ConfigParamsPersistence.h"
 
@@ -92,8 +91,6 @@ int main()
         error("failed to accommodate URI");
     }
 
-    // Setup auxiliary services to allow over-the-air firmware updates, etc
-    DFUService *dfu = new DFUService(ble);
     DeviceInformationService *deviceInfo = new DeviceInformationService(ble, "ARM", "UriBeacon", "SN1", "hw-rev1", "fw-rev1", "soft-rev1");
 
     ble.startAdvertising(); /* Set the whole thing in motion. After this call a GAP central can scan the URIBeaconConfig

--- a/BLE_URIBeacon/source/nrfConfigParamsPersistence.cpp
+++ b/BLE_URIBeacon/source/nrfConfigParamsPersistence.cpp
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-extern "C" {
-#include "pstorage.h"
-}
-
-#include "nrf_error.h"
 #include "ConfigParamsPersistence.h"
 
 /**
@@ -42,6 +37,14 @@ struct PersistentParams_t {
  * pass it on to the 'pstorage' APIs.
  */
 static PersistentParams_t persistentParams;
+
+#if defined(TARGET_NORDIC)
+
+extern "C" {
+#include "pstorage.h"
+}
+
+#include "nrf_error.h"
 
 static pstorage_handle_t pstorageHandle;
 
@@ -104,3 +107,28 @@ void saveURIBeaconConfigParams(const URIBeaconConfigService::Params_t *paramsP)
                         0 /* offset */);
     }
 }
+
+#else 
+
+/* In memory implementation */
+bool loadURIBeaconConfigParams(URIBeaconConfigService::Params_t *paramsP)
+{
+    static bool pstorageInitied = false;
+    if (!pstorageInitied) {
+        memset(&persistentParams.params, 0, sizeof(URIBeaconConfigService::Params_t));
+        memset(paramsP, 0, sizeof(URIBeaconConfigService::Params_t));
+        pstorageInitied = true;
+        return false;
+    }
+
+    memcpy(paramsP, &persistentParams.params, sizeof(URIBeaconConfigService::Params_t));
+    return true;
+}
+
+/* In memory implementation */
+void saveURIBeaconConfigParams(const URIBeaconConfigService::Params_t *paramsP)
+{
+	memcpy(&persistentParams.params, paramsP, sizeof(URIBeaconConfigService::Params_t));
+}
+
+#endif 


### PR DESCRIPTION
This set of patch improve the portability of BLE_URIBeacon example by removing references to the DFU and providing an in memory implementation of persistence functions.

It should fix #58 