### PR TITLE
Updating mbed-os to mbed-os-5.4.0-rc2

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_EddystoneObserver/mbed-os.lib
+++ b/BLE_EddystoneObserver/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_EddystoneService/mbed-os.lib
+++ b/BLE_EddystoneService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff

--- a/BLE_URIBeacon/mbed-os.lib
+++ b/BLE_URIBeacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3a27568a505bbc0bb8eeb973109d3d39ce823d1c
+https://github.com/ARMmbed/mbed-os/#305f5c491e34d86098e9da91b322017549c189ff


### PR DESCRIPTION
Please test/merge this PR and then tag Master with mbed-os-5.4.0-rc2