### PR TITLE
Using predefined macro for EVENT SIZE.

### DIFF
--- a/BLE_BatteryLevel/source/main.cpp
+++ b/BLE_BatteryLevel/source/main.cpp
@@ -28,7 +28,7 @@ static const uint16_t uuid16_list[] = {GattService::UUID_BATTERY_SERVICE};
 static uint8_t batteryLevel = 50;
 static BatteryService* batteryServicePtr;
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *params)
 {

--- a/BLE_BatteryLevel/source/main.cpp
+++ b/BLE_BatteryLevel/source/main.cpp
@@ -28,9 +28,7 @@ static const uint16_t uuid16_list[] = {GattService::UUID_BATTERY_SERVICE};
 static uint8_t batteryLevel = 50;
 static BatteryService* batteryServicePtr;
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *params)
 {

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -21,9 +21,7 @@
 
 static iBeacon* ibeaconPtr;
 
-static EventQueue eventQueue(
-    /* event count */ 4 * /* event size */ 32    
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 /**
  * This function is called when the ble initialization process has failled

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -21,7 +21,7 @@
 
 static iBeacon* ibeaconPtr;
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 4 * EVENTS_EVENT_SIZE);
 
 /**
  * This function is called when the ble initialization process has failled

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -23,7 +23,7 @@
 DigitalOut  led1(LED1, 1);
 InterruptIn button(BLE_BUTTON_PIN_NAME);
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 10 * EVENTS_EVENT_SIZE);
 
 const static char     DEVICE_NAME[] = "Button";
 static const uint16_t uuid16_list[] = {ButtonService::BUTTON_SERVICE_UUID};

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -23,9 +23,7 @@
 DigitalOut  led1(LED1, 1);
 InterruptIn button(BLE_BUTTON_PIN_NAME);
 
-static EventQueue eventQueue(
-    /* event count */ 10 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 const static char     DEVICE_NAME[] = "Button";
 static const uint16_t uuid16_list[] = {ButtonService::BUTTON_SERVICE_UUID};

--- a/BLE_EddystoneObserver/source/main.cpp
+++ b/BLE_EddystoneObserver/source/main.cpp
@@ -20,7 +20,7 @@
 
 static const int URI_MAX_LENGTH = 18;             // Maximum size of service data in ADV packets
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 DigitalOut led1(LED1, 1);
 

--- a/BLE_EddystoneObserver/source/main.cpp
+++ b/BLE_EddystoneObserver/source/main.cpp
@@ -20,9 +20,7 @@
 
 static const int URI_MAX_LENGTH = 18;             // Maximum size of service data in ADV packets
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 DigitalOut led1(LED1, 1);
 

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -39,7 +39,7 @@ static const PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13};
 /* Values for radio power levels, provided by manufacturer. */
 static const PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 DigitalOut led(LED1, 1);
 

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -39,9 +39,7 @@ static const PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13};
 /* Values for radio power levels, provided by manufacturer. */
 static const PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 DigitalOut led(LED1, 1);
 

--- a/BLE_GAPButton/source/main.cpp
+++ b/BLE_GAPButton/source/main.cpp
@@ -31,7 +31,7 @@ const char DEVICE_NAME[] = "GAPButton";
 #define GAPButtonUUID 0xAA00
 const uint16_t uuid16_list[] = {GAPButtonUUID};
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 void print_error(ble_error_t error, const char* msg)
 {

--- a/BLE_GAPButton/source/main.cpp
+++ b/BLE_GAPButton/source/main.cpp
@@ -31,9 +31,7 @@ const char DEVICE_NAME[] = "GAPButton";
 #define GAPButtonUUID 0xAA00
 const uint16_t uuid16_list[] = {GAPButtonUUID};
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 void print_error(ble_error_t error, const char* msg)
 {

--- a/BLE_HeartRate/source/main.cpp
+++ b/BLE_HeartRate/source/main.cpp
@@ -28,7 +28,7 @@ static const uint16_t uuid16_list[] = {GattService::UUID_HEART_RATE_SERVICE};
 static uint8_t hrmCounter = 100; // init HRM to 100bps
 static HeartRateService *hrServicePtr;
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *params)
 {

--- a/BLE_HeartRate/source/main.cpp
+++ b/BLE_HeartRate/source/main.cpp
@@ -28,9 +28,7 @@ static const uint16_t uuid16_list[] = {GattService::UUID_HEART_RATE_SERVICE};
 static uint8_t hrmCounter = 100; // init HRM to 100bps
 static HeartRateService *hrServicePtr;
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *params)
 {

--- a/BLE_LED/source/main.cpp
+++ b/BLE_LED/source/main.cpp
@@ -25,7 +25,7 @@ DigitalOut actuatedLED(LED2, 0);
 const static char     DEVICE_NAME[] = "LED";
 static const uint16_t uuid16_list[] = {LEDService::LED_SERVICE_UUID};
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 10 * EVENTS_EVENT_SIZE);
 
 LEDService *ledServicePtr;
 

--- a/BLE_LED/source/main.cpp
+++ b/BLE_LED/source/main.cpp
@@ -25,9 +25,7 @@ DigitalOut actuatedLED(LED2, 0);
 const static char     DEVICE_NAME[] = "LED";
 static const uint16_t uuid16_list[] = {LEDService::LED_SERVICE_UUID};
 
-static EventQueue eventQueue(
-    /* event count */ 10 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 LEDService *ledServicePtr;
 

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -25,7 +25,7 @@ static DiscoveredCharacteristic ledCharacteristic;
 static bool triggerLedCharacteristic;
 static const char PEER_NAME[] = "LED";
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 void periodicCallback(void) {
     alivenessLED = !alivenessLED; /* Do blinky on LED1 while we're waiting for BLE events */

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -25,9 +25,7 @@ static DiscoveredCharacteristic ledCharacteristic;
 static bool triggerLedCharacteristic;
 static const char PEER_NAME[] = "LED";
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32    
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 void periodicCallback(void) {
     alivenessLED = !alivenessLED; /* Do blinky on LED1 while we're waiting for BLE events */

--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -27,9 +27,7 @@ static const uint16_t uuid16_list[]        = {GattService::UUID_HEALTH_THERMOMET
 static float                     currentTemperature   = 39.6;
 static HealthThermometerService *thermometerServicePtr;
 
-static EventQueue eventQueue(
-    /* event count */ 16 * /* event size */ 32
-);
+static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
 
 /* Restart Advertising on disconnection*/
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *)

--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -27,7 +27,7 @@ static const uint16_t uuid16_list[]        = {GattService::UUID_HEALTH_THERMOMET
 static float                     currentTemperature   = 39.6;
 static HealthThermometerService *thermometerServicePtr;
 
-static EventQueue eventQueue(EVENTS_QUEUE_SIZE);
+static EventQueue eventQueue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
 /* Restart Advertising on disconnection*/
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *)


### PR DESCRIPTION
mbed OS defines a macro for EVENT QUEUE SIZE in EventQueue.h as 

#define EVENTS_QUEUE_SIZE (32*EVENTS_EVENT_SIZE) where EVENTS_EVENT_SIZE is:

#define EVENTS_EVENT_SIZE \
    (EQUEUE_EVENT_SIZE - 2*sizeof(void*) + sizeof(mbed::Callback<void()>))

Using this pre-supplied macro is helpful rather than hard coding the event size as 16*32. For most cases this hard coding will be sufficient. But in order to make it safe for future & avoid potential queue under run, slightly modifying the code to use the pre-defined macro.

Tested on nRF52_DK platform.

Also resolves this issue: https://github.com/ARMmbed/mbed-os-example-ble/issues/49 
