### PR TITLE
Change non-volatile storage driver for nRF51 to use fstorage

### DIFF
--- a/BLE_EddystoneService/source/PersistentStorageHelper/ConfigParamsPersistence.cpp
+++ b/BLE_EddystoneService/source/PersistentStorageHelper/ConfigParamsPersistence.cpp
@@ -16,7 +16,7 @@
 
 #include "ConfigParamsPersistence.h"
 
-#ifndef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+#if !defined(TARGET_NRF51822) && !defined(TARGET_NRF52832) /* Persistent storage supported on nrf51/nrf52 platforms */
     /**
      * When not using an nRF51-based target then persistent storage is not available.
      */


### PR DESCRIPTION
pstorage is deprecated and no longer works in mbed OS 5.4 projects due to https://github.com/ARMmbed/mbed-os/issues/4181. This updates the driver to use fstorage, and also makes the driver work on nRF52.

@pan- 