### PR TITLE
Updating mbed-os to mbed-os-5.5.3

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_EddystoneObserver/mbed-os.lib
+++ b/BLE_EddystoneObserver/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_EddystoneService/mbed-os.lib
+++ b/BLE_EddystoneService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8828635da469162cf2854b5287561c663fb96e72
+https://github.com/ARMmbed/mbed-os/#ed9d1da9dd0c43907ba40cba5ebd9f2c6da3dc07


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.5.3 . 