### PR TITLE
Updating mbed-os to mbed-os-5.5.7

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_EddystoneObserver/mbed-os.lib
+++ b/BLE_EddystoneObserver/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_EddystoneService/mbed-os.lib
+++ b/BLE_EddystoneService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#98ba8acb83cfc65f30a8a0771a27c71443ab093a
+https://github.com/ARMmbed/mbed-os/#ca661f9d28526ca8f874b05432493a489c9671ea


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.5.7 . 