### PR TITLE
Change name of nRF mobile app in example

### DIFF
--- a/BLE_Beacon/readme.md
+++ b/BLE_Beacon/readme.md
@@ -10,7 +10,7 @@ This example advertises a UUID, a major and minor number and the transmission st
 
 The sample application can be seen on any BLE scanner on a smartphone. If you don't have a scanner on your phone, please install :
 
-- [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp) for Android.
+- [nRF Connect for Mobile](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp) for Android.
 
 - [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8) for iPhone.
 


### PR DESCRIPTION
Seems the app went under a name change. Was a bit confusing at first, so it may help to change it in the docs.