### PR TITLE
Updating mbed-os to mbed-os-5.6.6

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#182bbd51bc8d1b6217477c2b5de3f1d0c5e6249f
+https://github.com/ARMmbed/mbed-os/#5f6572179d66ce4c09d6517b659ac51133cc980d


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.6.6 . 