### PR TITLE
Use "mbed deploy" instead of "mbed update"

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ __To build an example:__
 1. Update the source tree:
 
 	```
-	mbed update
+	mbed deploy
 	```
 
 1. Run the build:


### PR DESCRIPTION
The user has just cloned the latest version of the project, so suggesting "mbed update" is confusing as there is nothing to update. We are using the update to gather all the dependencies, and "mbed deploy" is a better command to do this.