### PR TITLE
Fix a broken link replacing a github .md by a link into the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ As an example, this is the JSON bit which has to be added in the `target_overrid
         },
 ```
 
-<span> **Note:** You can get more informations about the configuration system in the [documentation](https://github.com/ARMmbed/mbed-os/blob/master/docs/config_system.md)</span>
+<span> **Note:** You can get more information about the configuration system in the [documentation](https://os.mbed.com/docs/latest/reference/configuration.html)</span>
 
 <span> **Important:** It is required to apply an hardware patch to the ST shield if it is used on a board with an Arduino connector. Check out https://developer.mbed.org/teams/ST/code/X_NUCLEO_IDB0XA1/ for more information.</span>
 


### PR DESCRIPTION
informations -> information
Change link https://github.com/ARMmbed/mbed-os/blob/master/docs/config_system.md to https://os.mbed.com/docs/latest/reference/configuration.html
Please check that the link to the documentation is the most appropriate one.
FYI @AnotherButler @MarceloSalazar 