### PR TITLE
Replace out of date tools instruction with reference to latest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,7 @@ Pre-Requisites
 --------------
 
 
-To build these examples, you need to have a computer with the following software installed:
-
-* [CMake](http://www.cmake.org/download/).
-* [mbed-cli](https://github.com/ARMmbed/mbed-cli). Please note that **mbed-cli has its own set of dependencies**, listed in the installation instructions.
-* [Python](https://www.python.org/downloads/).
-* [ARM GCC toolchain 4.9.x](https://launchpad.net/gcc-arm-embedded/+milestone/4.9-2015-q3-update).
-* A serial terminal emulator (e.g. screen, pySerial, cu).
-* If the OS used is Windows, the serial driver of the board has to be correctly installed.
-	* For boards with mbed interface firmware the installation instructions are located (here)[https://developer.mbed.org/handbook/Windows-serial-configuration]
-	* For nrf51-based board with a J-Link interface  please install the J-Link *software and documentation pack* available (here)[https://www.segger.com/jlink-software.html]
-
+To build these examples, you need to have a computer with software installed as described [here](https://os.mbed.com/docs/latest/tools/setup.html).
 
 In order to use BLE in mbed OS you need one of the following hardware combinations:
 


### PR DESCRIPTION
The prerequisites section duplicates information in the docs, and is therefore harder to maintain, so replace with a link into the latest docs which describe the same things more comprehensively, and will be kept up to date.
FYI @AnotherButler @MarceloSalazar 