### PR TITLE
Remove ST support from Security Manager example

### DIFF
--- a/BLE_SM/README.md
+++ b/BLE_SM/README.md
@@ -26,4 +26,4 @@ Hardware requirements are in the [main readme](https://github.com/ARMmbed/mbed-o
 
 Building instructions for all samples are in the [main readme](https://github.com/ARMmbed/mbed-os-example-ble/blob/master/README.md).
 
-Note: example currently doesn't use ST provided stack and instead uses a Cordio port for the ST.
+Note: this example currently is currently not supported on ST BLUENRG targets.

--- a/BLE_SM/mbed_app.json
+++ b/BLE_SM/mbed_app.json
@@ -1,16 +1,2 @@
 {
-    "target_overrides": {
-        "K64F": {
-            "target.features_add": ["BLE"],
-            "target.extra_labels_add": ["ST_BLUENRG"]
-        },
-        "NUCLEO_F401RE": {
-            "target.features_add": ["BLE"],
-            "target.extra_labels_add": ["ST_BLUENRG", "CORDIO"]
-        },
-        "DISCO_L475VG_IOT01A": {
-            "target.features_add": ["BLE"],
-            "target.extra_labels_add": ["ST_BLUENRG", "CORDIO"]
-        }
-    }
 }

--- a/BLE_SM/shields/TARGET_ST_BLUENRG.lib
+++ b/BLE_SM/shields/TARGET_ST_BLUENRG.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/cordio-ble-x-nucleo-idb0xa1


### PR DESCRIPTION
This removes ST support for the Security Manager example as it's not supported by the ST host stack