### PR TITLE
Updating mbed-os to mbed-os-5.9.1

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#35fa909641fedcad9bbe0c7300d4ccdf15a2b71a
+https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.9.1 . 