### PR TITLE
Fix GattClient include typo

### DIFF
--- a/BLE_GattClient/BLEProcess.h
+++ b/BLE_GattClient/BLEProcess.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "events/Eventqueue.h"
+#include "events/EventQueue.h"
 #include "platform/Callback.h"
 #include "platform/NonCopyable.h"
 

--- a/BLE_GattClient/main.cpp
+++ b/BLE_GattClient/main.cpp
@@ -19,7 +19,7 @@
 #include <new>
 #include <stdio.h>
 
-#include "events/Eventqueue.h"
+#include "events/EventQueue.h"
 #include "platform/NonCopyable.h"
 
 #include "ble/BLE.h"


### PR DESCRIPTION
Corrected header include typo "events/Eventqueue.h" to "events/EventQueue.h" - it was causing the GattClient example to fail when compiling