### PR TITLE
Updating mbed-os to mbed-os-5.10.2

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.10.2 . 