### PR TITLE
Updating mbed-os to mbed-os-5.10.3

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482
+https://github.com/ARMmbed/mbed-os/#bf6f2c3c6434a6de9eb9511feffa5948b3d1f20f


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.10.3 . 