### PR TITLE
Fix type of current temperature of thermometer

### DIFF
--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -132,7 +132,7 @@ private:
 
     UUID _thermometer_uuid;
 
-    uint8_t _current_temperature;
+    float _current_temperature;
     HealthThermometerService *_thermometer_service;
 
     uint8_t _adv_buffer[ble::LEGACY_ADVERTISING_MAX_SIZE];


### PR DESCRIPTION
The type of `_current_temperature` should be declared as float, or the value won't change by increasing 0.1.