### PR TITLE
Initialized data and classes renamed

### DIFF
--- a/BLE_Button/mbed_app.json
+++ b/BLE_Button/mbed_app.json
@@ -39,6 +39,21 @@
         },
         "MTB_UBLOX_NINA_B1": {
             "ble_button_pin_name": "BUTTON1"
-        }            
+        },
+        "MTB_LAIRD_BL600": {
+            "ble_button_pin_name": "BUTTON1"
+        },
+        "MTB_LAIRD_BL652": {
+            "target.features_add": ["BLE"],
+            "target.extra_labels_add": ["CORDIO", "CORDIO_LL", "SOFTDEVICE_NONE", "NORDIC_CORDIO"],
+            "target.extra_labels_remove": ["SOFTDEVICE_COMMON", "SOFTDEVICE_S132_FULL", "NORDIC_SOFTDEVICE"],
+            "ble_button_pin_name": "BUTTON1"
+        },
+        "MTB_LAIRD_BL654": {
+            "target.features_add": ["BLE"],
+            "target.extra_labels_add": ["CORDIO", "CORDIO_LL", "SOFTDEVICE_NONE", "NORDIC_CORDIO"],
+            "target.extra_labels_remove": ["SOFTDEVICE_COMMON", "SOFTDEVICE_S132_FULL", "NORDIC_SOFTDEVICE"],
+            "ble_button_pin_name": "BUTTON1"
+        }        
     }
 }

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -26,9 +26,9 @@ const static char DEVICE_NAME[] = "Button";
 static EventQueue event_queue(/* event count */ 10 * EVENTS_EVENT_SIZE);
 
 
-class BatteryDemo : ble::Gap::EventHandler {
+class ButtonDemo : ble::Gap::EventHandler {
 public:
-    BatteryDemo(BLE &ble, events::EventQueue &event_queue) :
+    ButtonDemo(BLE &ble, events::EventQueue &event_queue) :
         _ble(ble),
         _event_queue(event_queue),
         _led1(LED1, 1),
@@ -40,9 +40,9 @@ public:
     void start() {
         _ble.gap().setEventHandler(this);
 
-        _ble.init(this, &BatteryDemo::on_init_complete);
+        _ble.init(this, &ButtonDemo::on_init_complete);
 
-        _event_queue.call_every(500, this, &BatteryDemo::blink);
+        _event_queue.call_every(500, this, &ButtonDemo::blink);
 
         _event_queue.dispatch_forever();
     }
@@ -61,8 +61,8 @@ private:
 
         _button_service = new ButtonService(_ble, false /* initial value for button pressed */);
 
-        _button.fall(Callback<void()>(this, &BatteryDemo::button_pressed));
-        _button.rise(Callback<void()>(this, &BatteryDemo::button_released));
+        _button.fall(Callback<void()>(this, &ButtonDemo::button_pressed));
+        _button.rise(Callback<void()>(this, &ButtonDemo::button_released));
 
         start_advertising();
     }
@@ -75,13 +75,9 @@ private:
             ble::adv_interval_t(ble::millisecond_t(1000))
         );
 
-        uint8_t adv_buffer[ble::LEGACY_ADVERTISING_MAX_SIZE];
-
-        ble::AdvertisingDataBuilder adv_data_builder(adv_buffer);
-
-        adv_data_builder.setFlags();
-        adv_data_builder.setLocalServiceList(mbed::make_Span(&_button_uuid, 1));
-        adv_data_builder.setName(DEVICE_NAME);
+        _adv_data_builder.setFlags();
+        _adv_data_builder.setLocalServiceList(mbed::make_Span(&_button_uuid, 1));
+        _adv_data_builder.setName(DEVICE_NAME);
 
         /* Setup advertising */
 
@@ -158,7 +154,7 @@ int main()
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(schedule_ble_events);
 
-    BatteryDemo demo(ble, event_queue);
+    ButtonDemo demo(ble, event_queue);
     demo.start();
 
     return 0;

--- a/BLE_GAPButton/mbed_app.json
+++ b/BLE_GAPButton/mbed_app.json
@@ -39,6 +39,21 @@
         },
         "MTB_UBLOX_NINA_B1": {
             "ble_button_pin_name": "BUTTON1"
-        }            
+        },
+        "MTB_LAIRD_BL600": {
+            "ble_button_pin_name": "BUTTON1"
+        },
+        "MTB_LAIRD_BL652": {
+            "target.features_add": ["BLE"],
+            "target.extra_labels_add": ["CORDIO", "CORDIO_LL", "SOFTDEVICE_NONE", "NORDIC_CORDIO"],
+            "target.extra_labels_remove": ["SOFTDEVICE_COMMON", "SOFTDEVICE_S132_FULL", "NORDIC_SOFTDEVICE"],
+            "ble_button_pin_name": "BUTTON1"
+        },
+        "MTB_LAIRD_BL654": {
+            "target.features_add": ["BLE"],
+            "target.extra_labels_add": ["CORDIO", "CORDIO_LL", "SOFTDEVICE_NONE", "NORDIC_CORDIO"],
+            "target.extra_labels_remove": ["SOFTDEVICE_COMMON", "SOFTDEVICE_S132_FULL", "NORDIC_SOFTDEVICE"],
+            "ble_button_pin_name": "BUTTON1"
+        }        
     }
 }

--- a/BLE_GAPButton/source/main.cpp
+++ b/BLE_GAPButton/source/main.cpp
@@ -37,6 +37,7 @@ public:
          * https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx */
         _button_uuid(0xAA00),
         _button(BLE_BUTTON_PIN_NAME),
+        _button_count(0),
         _adv_data_builder(_adv_buffer) { }
 
     ~GapButtonDemo()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// This is internal file to run tests in internal Jenkins
+mbed-os-example-ble-tests.run_job()


### PR DESCRIPTION
DO NOT MERGE
Correctly add a payload in the 2 button examples (was in one case sending uninitialized data)
Renamed BatteryDemo skeleton class to whatever the example name was.