### PR TITLE
Updating mbed-os to mbed-os-5.12.0-rc3

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_BatteryLevel/mbed-os.lib
+++ b/deprecated/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_Beacon/mbed-os.lib
+++ b/deprecated/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_Button/mbed-os.lib
+++ b/deprecated/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_GAP/mbed-os.lib
+++ b/deprecated/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_GAPButton/mbed-os.lib
+++ b/deprecated/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_GattClient/mbed-os.lib
+++ b/deprecated/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_GattServer/mbed-os.lib
+++ b/deprecated/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_HeartRate/mbed-os.lib
+++ b/deprecated/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_LED/mbed-os.lib
+++ b/deprecated/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_LEDBlinker/mbed-os.lib
+++ b/deprecated/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_Privacy/mbed-os.lib
+++ b/deprecated/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_SM/mbed-os.lib
+++ b/deprecated/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b

--- a/deprecated/BLE_Thermometer/mbed-os.lib
+++ b/deprecated/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c0939781ea1fa50657e055867193b62b1c9a6035
+https://github.com/ARMmbed/mbed-os/#85cbc290a2b4a5458cc1ae98c2a5bd6a4fd8758b


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.12.0-rc3 . 