### PR TITLE
BLE_Button: Fix advertising settings

### DIFF
--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -75,13 +75,9 @@ private:
             ble::adv_interval_t(ble::millisecond_t(1000))
         );
 
-        uint8_t adv_buffer[ble::LEGACY_ADVERTISING_MAX_SIZE];
-
-        ble::AdvertisingDataBuilder adv_data_builder(adv_buffer);
-
-        adv_data_builder.setFlags();
-        adv_data_builder.setLocalServiceList(mbed::make_Span(&_button_uuid, 1));
-        adv_data_builder.setName(DEVICE_NAME);
+        _adv_data_builder.setFlags();
+        _adv_data_builder.setLocalServiceList(mbed::make_Span(&_button_uuid, 1));
+        _adv_data_builder.setName(DEVICE_NAME);
 
         /* Setup advertising */
 


### PR DESCRIPTION
It seems that the example is broken and the "Button" device name is not advertised properly,
at least when testing with NUCLEO_WB55RG.

By comparing the example structure with HearRate, it seems that the advertising data in BLE_Button example is stored in a local variable of start_advertising data which may not be valid in memory after the function execution.

Aligning the implementation to HeartRate example seems to fix the problem.