### PR TITLE
Define BLE BUTTON for NUCLEO_WB55RG

### DIFF
--- a/BLE_Button/mbed_app.json
+++ b/BLE_Button/mbed_app.json
@@ -4,6 +4,11 @@
             "help": "The pin name used as button in this application",
             "macro_name": "BLE_BUTTON_PIN_NAME",
             "required": true
+        },
+        "ble_button_pin_pull": {
+            "help": "The BLE button may need a pull-up. Possible values are PullUp, PullDown, PullNone (default).",
+            "macro_name": "BLE_BUTTON_PIN_PULL",
+            "value": "PullNone"
         }
     },
     "target_overrides": {
@@ -25,6 +30,10 @@
             "target.extra_labels_add": ["CORDIO", "CORDIO_BLUENRG"],
             "ble_button_pin_name": "USER_BUTTON"
         },
+        "NUCLEO_WB55RG": {
+            "ble_button_pin_name": "USER_BUTTON",
+            "ble_button_pin_pull": "PullUp"
+        },
         "NRF52840_DK": {
             "target.features_add": ["BLE"],
             "target.extra_labels_add": ["CORDIO", "CORDIO_LL", "SOFTDEVICE_NONE", "NORDIC_CORDIO"],
@@ -39,6 +48,6 @@
         },
         "MTB_UBLOX_NINA_B1": {
             "ble_button_pin_name": "BUTTON1"
-        }            
+        }
     }
 }

--- a/BLE_Button/source/main.cpp
+++ b/BLE_Button/source/main.cpp
@@ -32,7 +32,7 @@ public:
         _ble(ble),
         _event_queue(event_queue),
         _led1(LED1, 1),
-        _button(BLE_BUTTON_PIN_NAME),
+        _button(BLE_BUTTON_PIN_NAME, BLE_BUTTON_PIN_PULL),
         _button_service(NULL),
         _button_uuid(ButtonService::BUTTON_SERVICE_UUID),
         _adv_data_builder(_adv_buffer) { }

--- a/BLE_GAPButton/mbed_app.json
+++ b/BLE_GAPButton/mbed_app.json
@@ -4,6 +4,11 @@
             "help": "The pin name used as button in this application",
             "macro_name": "BLE_BUTTON_PIN_NAME",
             "required": true
+        },
+        "ble_button_pin_pull": {
+            "help": "The BLE button may need a pull-up. Possible values are PullUp, PullDown, PullNone (default).",
+            "macro_name": "BLE_BUTTON_PIN_PULL",
+            "value": "PullNone"
         }
     },
     "target_overrides": {
@@ -24,6 +29,10 @@
             "target.features_add": ["BLE"],
             "target.extra_labels_add": ["CORDIO", "CORDIO_BLUENRG"],
             "ble_button_pin_name": "USER_BUTTON"
+        },
+        "NUCLEO_WB55RG": {
+            "ble_button_pin_name": "USER_BUTTON",
+            "ble_button_pin_pull": "PullUp"
         },
         "NRF52840_DK": {
             "target.features_add": ["BLE"],

--- a/BLE_GAPButton/source/main.cpp
+++ b/BLE_GAPButton/source/main.cpp
@@ -36,7 +36,7 @@ public:
          * as long as it does not overlap with the UUIDs defined here:
          * https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx */
         _button_uuid(0xAA00),
-        _button(BLE_BUTTON_PIN_NAME),
+        _button(BLE_BUTTON_PIN_NAME, BLE_BUTTON_PIN_PULL),
         _adv_data_builder(_adv_buffer) { }
 
     ~GapButtonDemo()


### PR DESCRIPTION
NUCLEO_WB55RG requires a PullUp to work properly.
So a PullUp configuration option is added to mbed_app.json.