### PR TITLE
Update thermometer test to use current APIs

### DIFF
--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -26,9 +26,9 @@ const static char DEVICE_NAME[] = "Therm";
 
 static events::EventQueue event_queue(/* event count */ 16 * EVENTS_EVENT_SIZE);
 
-class BatteryDemo : ble::Gap::EventHandler {
+class ThermometerDemo : ble::Gap::EventHandler {
 public:
-    BatteryDemo(BLE &ble, events::EventQueue &event_queue) :
+    ThermometerDemo(BLE &ble, events::EventQueue &event_queue) :
         _ble(ble),
         _event_queue(event_queue),
         _sensor_event_id(0),
@@ -40,9 +40,9 @@ public:
     void start() {
         _ble.gap().setEventHandler(this);
 
-        _ble.init(this, &BatteryDemo::on_init_complete);
+        _ble.init(this, &ThermometerDemo::on_init_complete);
 
-        _event_queue.call_every(500, this, &BatteryDemo::blink);
+        _event_queue.call_every(500, this, &ThermometerDemo::blink);
 
         _event_queue.dispatch_forever();
     }
@@ -127,7 +127,7 @@ private:
 
     virtual void onConnectionComplete(const ble::ConnectionCompleteEvent &event) {
         if (event.getStatus() == BLE_ERROR_NONE) {
-            _sensor_event_id = _event_queue.call_every(1000, this, &BatteryDemo::update_sensor_value);
+            _sensor_event_id = _event_queue.call_every(1000, this, &ThermometerDemo::update_sensor_value);
         }
     }
 
@@ -156,7 +156,7 @@ int main()
     BLE &ble = BLE::Instance();
     ble.onEventsToProcess(schedule_ble_events);
 
-    BatteryDemo demo(ble, event_queue);
+    ThermometerDemo demo(ble, event_queue);
     demo.start();
 
     return 0;

--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -33,7 +33,7 @@ public:
         _event_queue(event_queue),
         _sensor_event_id(0),
         _thermometer_uuid(GattService::UUID_HEALTH_THERMOMETER_SERVICE),
-        _current_temperature(39.6),
+        _current_temperature(39.6f),
         _thermometer_service(NULL),
         _adv_data_builder(_adv_buffer) { }
 
@@ -109,7 +109,7 @@ private:
     }
 
     void update_sensor_value() {
-        _current_temperature = (_current_temperature + 0.1 > 43.0) ? 39.6 : _current_temperature + 0.1;
+        _current_temperature = (_current_temperature + 0.1f > 43.0f) ? 39.6f : _current_temperature + 0.1f;
         _thermometer_service->updateTemperature(_current_temperature);
     }
 
@@ -139,7 +139,7 @@ private:
 
     UUID _thermometer_uuid;
 
-    uint8_t _current_temperature;
+    float _current_temperature;
     HealthThermometerService *_thermometer_service;
 
     uint8_t _adv_buffer[ble::LEGACY_ADVERTISING_MAX_SIZE];

--- a/BLE_Thermometer/source/pretty_printer.h
+++ b/BLE_Thermometer/source/pretty_printer.h
@@ -58,7 +58,10 @@ inline void print_error(ble_error_t error, const char* msg)
             printf("BLE_ERROR_UNSPECIFIED: Unknown error");
             break;
         case BLE_ERROR_INTERNAL_STACK_FAILURE:
-            printf("BLE_ERROR_INTERNAL_STACK_FAILURE: internal stack faillure");
+            printf("BLE_ERROR_INTERNAL_STACK_FAILURE: internal stack failure");
+            break;
+        case BLE_ERROR_NOT_FOUND:
+            printf("BLE_ERROR_NOT_FOUND");
             break;
     }
     printf("\r\n");


### PR DESCRIPTION
This PR is to fix several deprecated API calls in BLE_Thermometer.

Note: This does **NOT** fix any deprecation warnings than come from _mbed-os_ itself. I'll create a separate/independent PR for that.

Also:
* Fix class name - it's obviously not BatteryDemo...
* Fix temperature variable type