### PR TITLE
Updating mbed-os to mbed-os-5.13.0

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_BatteryLevel/mbed-os.lib
+++ b/deprecated/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_Beacon/mbed-os.lib
+++ b/deprecated/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_Button/mbed-os.lib
+++ b/deprecated/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_GAP/mbed-os.lib
+++ b/deprecated/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_GAPButton/mbed-os.lib
+++ b/deprecated/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_GattClient/mbed-os.lib
+++ b/deprecated/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_GattServer/mbed-os.lib
+++ b/deprecated/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_HeartRate/mbed-os.lib
+++ b/deprecated/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_LED/mbed-os.lib
+++ b/deprecated/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_LEDBlinker/mbed-os.lib
+++ b/deprecated/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_Privacy/mbed-os.lib
+++ b/deprecated/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_SM/mbed-os.lib
+++ b/deprecated/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e

--- a/deprecated/BLE_Thermometer/mbed-os.lib
+++ b/deprecated/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#92a58dff9960788a3582b0f6dced1d5280b7f2f8
+https://github.com/ARMmbed/mbed-os/#7482462434d5cf718177653ef797547a976a7c5e


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.13.0 . 