### PR TITLE
Updating mbed-os to mbed-os-5.13.3

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_BatteryLevel/mbed-os.lib
+++ b/deprecated/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_Beacon/mbed-os.lib
+++ b/deprecated/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_Button/mbed-os.lib
+++ b/deprecated/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_GAP/mbed-os.lib
+++ b/deprecated/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_GAPButton/mbed-os.lib
+++ b/deprecated/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_GattClient/mbed-os.lib
+++ b/deprecated/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_GattServer/mbed-os.lib
+++ b/deprecated/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_HeartRate/mbed-os.lib
+++ b/deprecated/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_LED/mbed-os.lib
+++ b/deprecated/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_LEDBlinker/mbed-os.lib
+++ b/deprecated/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_Privacy/mbed-os.lib
+++ b/deprecated/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_SM/mbed-os.lib
+++ b/deprecated/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c

--- a/deprecated/BLE_Thermometer/mbed-os.lib
+++ b/deprecated/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#5941d1718339116cd12914238ec331c84da3d08f
+https://github.com/ARMmbed/mbed-os/#808c45062f940790e1287bd6b8420290c062775c


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.13.3 . 