### PR TITLE
Updating mbed-os to mbed-os-5.15.0-rc2

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_BatteryLevel/mbed-os.lib
+++ b/deprecated/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_Beacon/mbed-os.lib
+++ b/deprecated/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_Button/mbed-os.lib
+++ b/deprecated/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_GAP/mbed-os.lib
+++ b/deprecated/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_GAPButton/mbed-os.lib
+++ b/deprecated/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_GattClient/mbed-os.lib
+++ b/deprecated/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_GattServer/mbed-os.lib
+++ b/deprecated/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_HeartRate/mbed-os.lib
+++ b/deprecated/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_LED/mbed-os.lib
+++ b/deprecated/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_LEDBlinker/mbed-os.lib
+++ b/deprecated/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_Privacy/mbed-os.lib
+++ b/deprecated/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_SM/mbed-os.lib
+++ b/deprecated/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d

--- a/deprecated/BLE_Thermometer/mbed-os.lib
+++ b/deprecated/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b14f495aa23fc62355abd9f892f55c34731ce606
+https://github.com/ARMmbed/mbed-os/#5d7f5bd82b5cc9114818ec2f708b6a1c4ec6206d


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.15.0-rc2 . 