### PR TITLE
fixed a bug in BLE_GattClient

### DIFF
--- a/BLE_GattClient/source/main.cpp
+++ b/BLE_GattClient/source/main.cpp
@@ -486,7 +486,7 @@ private:
         DiscoveredCharacteristicNode* new_node =
             new(std::nothrow) DiscoveredCharacteristicNode(*characteristic);
 
-        if (new_node == false) {
+        if (new_node == NULL) {
             printf("Error while allocating a new characteristic.\r\n");
             return false;
         }


### PR DESCRIPTION
This caused an error while adding the test for this example:
```
./source/main.cpp:489:22: error: comparison between pointer and integer
```
