### PR TITLE
Remove wait deprecated API usage

### DIFF
--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -769,7 +769,7 @@ int main()
 
     while (1) {
         demo.run();
-        wait_ms(TIME_BETWEEN_MODES_MS);
+        thread_sleep_for(TIME_BETWEEN_MODES_MS);
         printf("\r\nStarting next GAP demo mode\r\n");
     };
 


### PR DESCRIPTION
`wait` and `wait_ms` are removed from Mbed OS source in the [PR#12572](https://github.com/ARMmbed/mbed-os/pull/12572), so modified source to use thread_sleep_for API.

### Reviewers <!-- Optional -->
@evedon, @donatieng @pan- 