### PR TITLE
Fix deprecated Gap type usages

### DIFF
--- a/BLE_BatteryLevel/source/pretty_printer.h
+++ b/BLE_BatteryLevel/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Beacon/source/pretty_printer.h
+++ b/BLE_Beacon/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Button/source/pretty_printer.h
+++ b/BLE_Button/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -443,7 +443,7 @@ private:
             /* skip non discoverable device */
             if (field.type != ble::adv_data_type_t::FLAGS ||
                 field.value.size() != 1 ||
-                !(field.value[0] & GapAdvertisingData::LE_GENERAL_DISCOVERABLE)) {
+                !ble::adv_data_flags_t(field.value[0]).getGeneralDiscoverable()) {
                 continue;
             }
 

--- a/BLE_GAP/source/pretty_printer.h
+++ b/BLE_GAP/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GAPButton/source/pretty_printer.h
+++ b/BLE_GAPButton/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GattClient/source/main.cpp
+++ b/BLE_GattClient/source/main.cpp
@@ -250,7 +250,7 @@ private:
      *
      * @see GattClient::onServiceDiscoveryTermination
      */
-    void when_service_discovery_ends(Gap::Handle_t connection_handle)
+    void when_service_discovery_ends(ble::connection_handle_t connection_handle)
     {
         if (!_characteristics) {
             printf("No characteristics discovered, end of the process.\r\n");
@@ -565,7 +565,7 @@ private:
     }
 
     GattClient *_client;
-    Gap::Handle_t _connection_handle;
+    ble::connection_handle_t _connection_handle;
     DiscoveredCharacteristicNode *_characteristics;
     DiscoveredCharacteristicNode *_it;
     GattAttribute::Handle_t _descriptor_handle;

--- a/BLE_GattClient/source/pretty_printer.h
+++ b/BLE_GattClient/source/pretty_printer.h
@@ -94,13 +94,13 @@ inline void print_mac_address()
     }
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GattServer/source/pretty_printer.h
+++ b/BLE_GattServer/source/pretty_printer.h
@@ -94,13 +94,13 @@ inline void print_mac_address()
     }
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_HeartRate/source/pretty_printer.h
+++ b/BLE_HeartRate/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_LED/source/pretty_printer.h
+++ b/BLE_LED/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -57,7 +57,7 @@ void characteristic_discovery(const DiscoveredCharacteristic *characteristicP) {
     }
 }
 
-void discovery_termination(Gap::Handle_t connectionHandle) {
+void discovery_termination(ble::connection_handle_t connectionHandle) {
     printf("terminated SD for handle %u\r\n", connectionHandle);
     if (trigger_led_characteristic) {
         trigger_led_characteristic = false;

--- a/BLE_LEDBlinker/source/pretty_printer.h
+++ b/BLE_LEDBlinker/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_PeriodicAdvertising/source/pretty_printer.h
+++ b/BLE_PeriodicAdvertising/source/pretty_printer.h
@@ -91,13 +91,13 @@ inline void print_mac_address()
     }
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Privacy/source/main.cpp
+++ b/BLE_Privacy/source/main.cpp
@@ -299,9 +299,9 @@ public:
             return;
         }
 
-        Gap::PeripheralPrivacyConfiguration_t privacy_configuration = {
+        ble::peripheral_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::PeripheralPrivacyConfiguration_t::PERFORM_PAIRING_PROCEDURE
+            ble::peripheral_privacy_configuration_t::PERFORM_PAIRING_PROCEDURE
         };
 
         _ble.gap().setPeripheralPrivacyConfiguration(&privacy_configuration);
@@ -313,9 +313,9 @@ public:
     virtual void start_after_bonding()
     {
         printf("start after bonding\r\n");
-        Gap::PeripheralPrivacyConfiguration_t privacy_configuration = {
+        ble::peripheral_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::PeripheralPrivacyConfiguration_t::REJECT_NON_RESOLVED_ADDRESS
+            ble::peripheral_privacy_configuration_t::REJECT_NON_RESOLVED_ADDRESS
         };
 
         _ble.gap().setPeripheralPrivacyConfiguration(&privacy_configuration);
@@ -408,9 +408,9 @@ public:
      *  and scan requests responses */
     virtual void start()
     {
-        Gap::CentralPrivacyConfiguration_t privacy_configuration = {
+        ble::central_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::CentralPrivacyConfiguration_t::DO_NOT_RESOLVE
+            ble::central_privacy_configuration_t::DO_NOT_RESOLVE
         };
 
         _ble.gap().setCentralPrivacyConfiguration(&privacy_configuration);
@@ -421,9 +421,9 @@ public:
     virtual void start_after_bonding()
     {
         printf("start after bonding\r\n");
-        Gap::CentralPrivacyConfiguration_t privacy_configuration = {
+        ble::central_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::CentralPrivacyConfiguration_t::RESOLVE_AND_FILTER
+            ble::central_privacy_configuration_t::RESOLVE_AND_FILTER
         };
 
         _ble.gap().setCentralPrivacyConfiguration(&privacy_configuration);

--- a/BLE_Privacy/source/pretty_printer.h
+++ b/BLE_Privacy/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_SM/source/main.cpp
+++ b/BLE_SM/source/main.cpp
@@ -156,13 +156,13 @@ private:
             printf("Error enabling privacy\r\n");
         }
 
-        Gap::PeripheralPrivacyConfiguration_t configuration_p = {
+        Gap::peripheral_privacy_configuration_t configuration_p = {
             /* use_non_resolvable_random_address */ false,
-            Gap::PeripheralPrivacyConfiguration_t::REJECT_NON_RESOLVED_ADDRESS
+            Gap::peripheral_privacy_configuration_t::REJECT_NON_RESOLVED_ADDRESS
         };
         _ble.gap().setPeripheralPrivacyConfiguration(&configuration_p);
 
-        Gap::CentralPrivacyConfiguration_t configuration_c = {
+        Gap::central_privay_configuration_t configuration_c = {
             /* use_non_resolvable_random_address */ false,
             Gap::CentralPrivacyConfiguration_t::RESOLVE_AND_FORWARD
         };

--- a/BLE_SM/source/pretty_printer.h
+++ b/BLE_SM/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Thermometer/source/pretty_printer.h
+++ b/BLE_Thermometer/source/pretty_printer.h
@@ -84,13 +84,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";


### PR DESCRIPTION
This PR replaces usages of deprecated types in `Gap::` that are not warned by the compiler but will not be available anymore once https://github.com/ARMmbed/mbed-os/pull/12730 is merged. (Note: This does **not** depend on that PR.)

Types replaced:
* `Gap::Phy_t` -> `ble::phy_t`
* `Gap::Handle_t` -> `ble::connection_handle_t`
* `GapAdvertisingData::LE_GENERAL_DISCOVERABLE` -> `ble::adv_data_flags_t(value).getGeneralDiscoverable()`
* `Gap::CentralPrivacyConfiguration_t` -> `ble::central_privacy_configuration_t`

The legacy types exist in the legacy Gap class only which will be removed from mbed-os. The current Gap APIs only use the new types.