### PR TITLE
Use new types for BLE address and Gap

### DIFF
--- a/BLE_BatteryLevel/source/pretty_printer.h
+++ b/BLE_BatteryLevel/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_BatteryLevel/source/pretty_printer.h
+++ b/BLE_BatteryLevel/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Beacon/source/pretty_printer.h
+++ b/BLE_Beacon/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_Beacon/source/pretty_printer.h
+++ b/BLE_Beacon/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Button/source/pretty_printer.h
+++ b/BLE_Button/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_Button/source/pretty_printer.h
+++ b/BLE_Button/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -443,7 +443,7 @@ private:
             /* skip non discoverable device */
             if (field.type != ble::adv_data_type_t::FLAGS ||
                 field.value.size() != 1 ||
-                !(field.value[0] & GapAdvertisingData::LE_GENERAL_DISCOVERABLE)) {
+                !ble::adv_data_flags_t(field.value[0]).getGeneralDiscoverable()) {
                 continue;
             }
 

--- a/BLE_GAP/source/pretty_printer.h
+++ b/BLE_GAP/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_GAP/source/pretty_printer.h
+++ b/BLE_GAP/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GAPButton/source/pretty_printer.h
+++ b/BLE_GAPButton/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_GAPButton/source/pretty_printer.h
+++ b/BLE_GAPButton/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GattClient/source/main.cpp
+++ b/BLE_GattClient/source/main.cpp
@@ -250,7 +250,7 @@ private:
      *
      * @see GattClient::onServiceDiscoveryTermination
      */
-    void when_service_discovery_ends(Gap::Handle_t connection_handle)
+    void when_service_discovery_ends(ble::connection_handle_t connection_handle)
     {
         if (!_characteristics) {
             printf("No characteristics discovered, end of the process.\r\n");
@@ -565,7 +565,7 @@ private:
     }
 
     GattClient *_client;
-    Gap::Handle_t _connection_handle;
+    ble::connection_handle_t _connection_handle;
     DiscoveredCharacteristicNode *_characteristics;
     DiscoveredCharacteristicNode *_it;
     GattAttribute::Handle_t _descriptor_handle;

--- a/BLE_GattClient/source/pretty_printer.h
+++ b/BLE_GattClient/source/pretty_printer.h
@@ -71,7 +71,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const uint8_t *addr)
+inline void print_address(const ble::address_t addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -80,16 +80,16 @@ inline void print_address(const uint8_t *addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 
     if (!seeded) {
         seeded = true;
         /* use the address as a seed */
-        uint8_t* random_data = address;
+        uint8_t* random_data = address.data();
         srand(*((unsigned int*)random_data));
     }
 }

--- a/BLE_GattClient/source/pretty_printer.h
+++ b/BLE_GattClient/source/pretty_printer.h
@@ -94,13 +94,13 @@ inline void print_mac_address()
     }
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_GattServer/source/pretty_printer.h
+++ b/BLE_GattServer/source/pretty_printer.h
@@ -71,7 +71,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const uint8_t *addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -80,16 +80,16 @@ inline void print_address(const uint8_t *addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 
     if (!seeded) {
         seeded = true;
         /* use the address as a seed */
-        uint8_t* random_data = address;
+        uint8_t* random_data = address.data();
         srand(*((unsigned int*)random_data));
     }
 }

--- a/BLE_GattServer/source/pretty_printer.h
+++ b/BLE_GattServer/source/pretty_printer.h
@@ -94,13 +94,13 @@ inline void print_mac_address()
     }
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_HeartRate/source/pretty_printer.h
+++ b/BLE_HeartRate/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_HeartRate/source/pretty_printer.h
+++ b/BLE_HeartRate/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_LED/source/pretty_printer.h
+++ b/BLE_LED/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_LED/source/pretty_printer.h
+++ b/BLE_LED/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -57,7 +57,7 @@ void characteristic_discovery(const DiscoveredCharacteristic *characteristicP) {
     }
 }
 
-void discovery_termination(Gap::Handle_t connectionHandle) {
+void discovery_termination(ble::connection_handle_t connectionHandle) {
     printf("terminated SD for handle %u\r\n", connectionHandle);
     if (trigger_led_characteristic) {
         trigger_led_characteristic = false;

--- a/BLE_LEDBlinker/source/pretty_printer.h
+++ b/BLE_LEDBlinker/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-void print_address(const uint8_t *addr)
+void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ void print_address(const uint8_t *addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_LEDBlinker/source/pretty_printer.h
+++ b/BLE_LEDBlinker/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_PeriodicAdvertising/source/pretty_printer.h
+++ b/BLE_PeriodicAdvertising/source/pretty_printer.h
@@ -91,13 +91,13 @@ inline void print_mac_address()
     }
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_PeriodicAdvertising/source/pretty_printer.h
+++ b/BLE_PeriodicAdvertising/source/pretty_printer.h
@@ -68,7 +68,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const uint8_t *addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -77,16 +77,16 @@ inline void print_address(const uint8_t *addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 
     if (!seeded) {
         seeded = true;
         /* use the address as a seed */
-        uint8_t* random_data = address;
+        uint8_t* random_data = address.data();
         srand(*((unsigned int*)random_data));
     }
 }

--- a/BLE_Privacy/source/main.cpp
+++ b/BLE_Privacy/source/main.cpp
@@ -172,16 +172,16 @@ public:
     void print_local_address()
     {
         /* show what address we are using now */
-        BLEProtocol::AddressType_t addr_type;
-        BLEProtocol::AddressBytes_t addr;
-        _ble.gap().getAddress(&addr_type, addr);
+        ble::own_address_type_t addr_type;
+        ble::address_t addr;
+        _ble.gap().getAddress(addr_type, addr);
         printf("Device address: ");
         print_address(addr);
 
         if (!_seeded) {
             _seeded = true;
             /* use the address as a seed */
-            uint8_t* random_data = addr;
+            uint8_t* random_data = addr.data();
             srand(*((unsigned int*)random_data));
         }
     }

--- a/BLE_Privacy/source/main.cpp
+++ b/BLE_Privacy/source/main.cpp
@@ -299,9 +299,9 @@ public:
             return;
         }
 
-        Gap::PeripheralPrivacyConfiguration_t privacy_configuration = {
+        ble::peripheral_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::PeripheralPrivacyConfiguration_t::PERFORM_PAIRING_PROCEDURE
+            ble::peripheral_privacy_configuration_t::PERFORM_PAIRING_PROCEDURE
         };
 
         _ble.gap().setPeripheralPrivacyConfiguration(&privacy_configuration);
@@ -313,9 +313,9 @@ public:
     virtual void start_after_bonding()
     {
         printf("start after bonding\r\n");
-        Gap::PeripheralPrivacyConfiguration_t privacy_configuration = {
+        ble::peripheral_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::PeripheralPrivacyConfiguration_t::REJECT_NON_RESOLVED_ADDRESS
+            ble::peripheral_privacy_configuration_t::REJECT_NON_RESOLVED_ADDRESS
         };
 
         _ble.gap().setPeripheralPrivacyConfiguration(&privacy_configuration);
@@ -408,9 +408,9 @@ public:
      *  and scan requests responses */
     virtual void start()
     {
-        Gap::CentralPrivacyConfiguration_t privacy_configuration = {
+        ble::central_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::CentralPrivacyConfiguration_t::DO_NOT_RESOLVE
+            ble::central_privacy_configuration_t::DO_NOT_RESOLVE
         };
 
         _ble.gap().setCentralPrivacyConfiguration(&privacy_configuration);
@@ -421,9 +421,9 @@ public:
     virtual void start_after_bonding()
     {
         printf("start after bonding\r\n");
-        Gap::CentralPrivacyConfiguration_t privacy_configuration = {
+        ble::central_privacy_configuration_t privacy_configuration = {
             /* use_non_resolvable_random_address */ false,
-            Gap::CentralPrivacyConfiguration_t::RESOLVE_AND_FILTER
+            ble::central_privacy_configuration_t::RESOLVE_AND_FILTER
         };
 
         _ble.gap().setCentralPrivacyConfiguration(&privacy_configuration);

--- a/BLE_Privacy/source/pretty_printer.h
+++ b/BLE_Privacy/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-void print_address(const uint8_t *addr)
+void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ void print_address(const uint8_t *addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_Privacy/source/pretty_printer.h
+++ b/BLE_Privacy/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_SM/source/main.cpp
+++ b/BLE_SM/source/main.cpp
@@ -156,13 +156,13 @@ private:
             printf("Error enabling privacy\r\n");
         }
 
-        Gap::PeripheralPrivacyConfiguration_t configuration_p = {
+        Gap::peripheral_privacy_configuration_t configuration_p = {
             /* use_non_resolvable_random_address */ false,
-            Gap::PeripheralPrivacyConfiguration_t::REJECT_NON_RESOLVED_ADDRESS
+            Gap::peripheral_privacy_configuration_t::REJECT_NON_RESOLVED_ADDRESS
         };
         _ble.gap().setPeripheralPrivacyConfiguration(&configuration_p);
 
-        Gap::CentralPrivacyConfiguration_t configuration_c = {
+        Gap::central_privay_configuration_t configuration_c = {
             /* use_non_resolvable_random_address */ false,
             Gap::CentralPrivacyConfiguration_t::RESOLVE_AND_FORWARD
         };

--- a/BLE_SM/source/main.cpp
+++ b/BLE_SM/source/main.cpp
@@ -48,7 +48,7 @@ const static disconnect_call_t disconnect_call = &Gap::disconnect;
 /* for demonstration purposes we will store the peer device address
  * of the device that connects to us in the first demonstration
  * so we can use its address to reconnect to it later */
-static BLEProtocol::AddressBytes_t peer_address;
+static ble::address_t peer_address;
 
 /** Base class for both peripheral and central. The same class that provides
  *  the logic for the application also implements the SecurityManagerEventHandler
@@ -61,7 +61,7 @@ class SMDevice : private mbed::NonCopyable<SMDevice>,
                  public ble::Gap::EventHandler
 {
 public:
-    SMDevice(BLE &ble, events::EventQueue &event_queue, BLEProtocol::AddressBytes_t &peer_address) :
+    SMDevice(BLE &ble, events::EventQueue &event_queue, ble::address_t &peer_address) :
         _led1(LED1, 0),
         _ble(ble),
         _event_queue(event_queue),
@@ -180,10 +180,7 @@ private:
         _ble.gap().setEventHandler(this);
 
         /* print device address */
-        BLEProtocol::AddressType_t addr_type;
-        BLEProtocol::AddressBytes_t addr;
-        _ble.gap().getAddress(&addr_type, addr);
-        print_address(addr);
+        print_mac_address();
 
         /* start test in 500 ms */
         _event_queue.call_in(500, this, &SMDevice::start);
@@ -278,7 +275,7 @@ private:
 protected:
     BLE &_ble;
     events::EventQueue &_event_queue;
-    BLEProtocol::AddressBytes_t &_peer_address;
+    ble::address_t &_peer_address;
     ble::connection_handle_t _handle;
     bool _is_connecting;
 };
@@ -287,7 +284,7 @@ protected:
  * a change in link security. */
 class SMDevicePeripheral : public SMDevice {
 public:
-    SMDevicePeripheral(BLE &ble, events::EventQueue &event_queue, BLEProtocol::AddressBytes_t &peer_address)
+    SMDevicePeripheral(BLE &ble, events::EventQueue &event_queue, ble::address_t &peer_address)
         : SMDevice(ble, event_queue, peer_address) { }
 
     virtual void start()
@@ -352,7 +349,7 @@ public:
 
         /* remember the device that connects to us now so we can connect to it
          * during the next demonstration */
-        memcpy(_peer_address, event.getPeerAddress().data(), sizeof(_peer_address));
+        _peer_address = event.getPeerAddress();
 
         printf("Connected to peer: ");
         print_address(event.getPeerAddress().data());
@@ -379,7 +376,7 @@ public:
 /** A central device will scan, connect to a peer and request pairing. */
 class SMDeviceCentral : public SMDevice {
 public:
-    SMDeviceCentral(BLE &ble, events::EventQueue &event_queue, BLEProtocol::AddressBytes_t &peer_address)
+    SMDeviceCentral(BLE &ble, events::EventQueue &event_queue, ble::address_t &peer_address)
         : SMDevice(ble, event_queue, peer_address) { }
 
     virtual void start()
@@ -403,7 +400,7 @@ public:
         printf("Please advertise\r\n");
 
         printf("Scanning for: ");
-        print_address(_peer_address);
+        print_address(_peer_address.data());
     }
 
 private:
@@ -418,7 +415,7 @@ private:
         }
 
         /* parse the advertising payload, looking for a discoverable device */
-        if (memcmp(event.getPeerAddress().data(), _peer_address, sizeof(_peer_address)) == 0) {
+        if (event.getPeerAddress() == _peer_address) {
             ble_error_t error = _ble.gap().stopScan();
 
             if (error) {

--- a/BLE_SM/source/pretty_printer.h
+++ b/BLE_SM/source/pretty_printer.h
@@ -65,7 +65,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-void print_address(const uint8_t *addr)
+void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -74,9 +74,9 @@ void print_address(const uint8_t *addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }

--- a/BLE_SM/source/pretty_printer.h
+++ b/BLE_SM/source/pretty_printer.h
@@ -81,13 +81,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Thermometer/source/pretty_printer.h
+++ b/BLE_Thermometer/source/pretty_printer.h
@@ -84,13 +84,13 @@ inline void print_mac_address()
     print_address(address);
 }
 
-inline const char* phy_to_string(Gap::Phy_t phy) {
+inline const char* phy_to_string(ble::phy_t phy) {
     switch(phy.value()) {
-        case Gap::Phy_t::LE_1M:
+        case ble::phy_t::LE_1M:
             return "LE 1M";
-        case Gap::Phy_t::LE_2M:
+        case ble::phy_t::LE_2M:
             return "LE 2M";
-        case Gap::Phy_t::LE_CODED:
+        case ble::phy_t::LE_CODED:
             return "LE coded";
         default:
             return "invalid PHY";

--- a/BLE_Thermometer/source/pretty_printer.h
+++ b/BLE_Thermometer/source/pretty_printer.h
@@ -68,7 +68,7 @@ inline void print_error(ble_error_t error, const char* msg)
 }
 
 /** print device address to the terminal */
-inline void print_address(const BLEProtocol::AddressBytes_t &addr)
+inline void print_address(const ble::address_t &addr)
 {
     printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
@@ -77,9 +77,9 @@ inline void print_address(const BLEProtocol::AddressBytes_t &addr)
 inline void print_mac_address()
 {
     /* Print out device MAC address to the console*/
-    BLEProtocol::AddressType_t addr_type;
-    BLEProtocol::AddressBytes_t address;
-    BLE::Instance().gap().getAddress(&addr_type, address);
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    BLE::Instance().gap().getAddress(addr_type, address);
     printf("DEVICE MAC ADDRESS: ");
     print_address(address);
 }


### PR DESCRIPTION
In https://github.com/ARMmbed/mbed-os/pull/12730 we have removed legacy address-related types (BLEProtocol:: namespace) in favour of new once in ble:: namespace. This PR updates examples
so they will continue to work the latest Mbed OS.

Changes:
* `BLEProtocol::AddressType_t` -> `ble::own_address_type_t`
* `BLEProtocol::AddressBytes_t` -> `ble::address_t`

Additionally, in #289 we fixed types for Gap, but it got reverted because it contains a typo fix which hasn't landed in mbed-os repo yet. This PR also brings that back.

* `Gap::Phy_t` -> `ble::phy_t`
* `Gap::Handle_t` -> `ble::connection_handle_t`
* `GapAdvertisingData::LE_GENERAL_DISCOVERABLE` -> `ble::adv_data_flags_t(value).getGeneralDiscoverable()`
* `Gap::CentralPrivacyConfiguration_t` -> `ble::central_privacy_configuration_t` (Note: currently spelt "privay" in mbed-os, corrected by https://github.com/ARMmbed/mbed-os/pull/12730)

Note: This change is in conjunction with https://github.com/ARMmbed/mbed-os/pull/12730 - they have to be merged roughly at the same time.