### PR TITLE
Fix CI bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,9 @@ jobs:
       - run: |
           cd mbed-os-example-ble
           git clone https://github.com/ARMmbed/mbed-os.git
-          mkdir BUILD
       - run:
           working_directory: mbed-os-example-ble
-          command: for i in BLE_* ; do cd $i ; ln -s $PWD/../mbed-os mbed-os ; ln -s $PWD/../BUILD BUILD ; cd .. ; done
+          command: for i in BLE_* ; do cd $i ; ln -s $PWD/../mbed-os mbed-os ; cd .. ; done
       - persist_to_workspace:
           root: /root/project
           paths: mbed-os-example-ble
@@ -31,7 +30,7 @@ jobs:
           at: /root/project
       - run: |
           cd mbed-os-example-ble
-          for i in BLE_* ; do cd $i ; mbed update ; mbed compile -t GCC_ARM -m NRF52840_DK || break ; cd .. ; done
+          for i in BLE_* ; do cd $i ; mbed update ; mbed compile -t GCC_ARM -m NRF52840_DK || exit 1 ; cd .. ; done
 
   build_disco_l475vg:
     docker:
@@ -42,7 +41,7 @@ jobs:
           at: /root/project
       - run: |
           cd mbed-os-example-ble
-          for i in BLE_* ; do cd $i ; mbed update ; mbed compile -t GCC_ARM -m DISCO_L475VG_IOT01A || break ; cd .. ; done
+          for i in BLE_* ; do cd $i ; mbed update ; mbed compile -t GCC_ARM -m DISCO_L475VG_IOT01A || exit 1 ; cd .. ; done
 
 workflows:
   version: 2


### PR DESCRIPTION
CI testing got some bugs:
1. Reuse of BUILD folder to speed up building process cause some image not been build properly. So disable the reuse of BUILD folder. 
2. Break command in bash not throw any error code, some build failure would be missed, change to `exit 1` to deliberate to throw errors if build failed 