### PR TITLE
Updating mbed-os to mbed-os-5.15.3

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_BatteryLevel/mbed-os.lib
+++ b/deprecated/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_Beacon/mbed-os.lib
+++ b/deprecated/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_Button/mbed-os.lib
+++ b/deprecated/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_GAP/mbed-os.lib
+++ b/deprecated/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_GAPButton/mbed-os.lib
+++ b/deprecated/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_GattClient/mbed-os.lib
+++ b/deprecated/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_GattServer/mbed-os.lib
+++ b/deprecated/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_HeartRate/mbed-os.lib
+++ b/deprecated/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_LED/mbed-os.lib
+++ b/deprecated/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_LEDBlinker/mbed-os.lib
+++ b/deprecated/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_Privacy/mbed-os.lib
+++ b/deprecated/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_SM/mbed-os.lib
+++ b/deprecated/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3

--- a/deprecated/BLE_Thermometer/mbed-os.lib
+++ b/deprecated/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#565ab149819481224ab43f878c3921b14b11d180
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag the corresponding 
release branch with mbed-os-5.15.3 . 