### PR TITLE
BLE_GAP: do not use CONNECTABLE_UNDIRECTED with extended advertising

### DIFF
--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -253,7 +253,9 @@ private:
             adv_params.type.value(),
             adv_params.min_interval.valueInMs(), adv_params.max_interval.valueInMs() );
 
-        if (is_extended_advertising_supported()) {
+        // CONNECTABLE_UNDIRECTED is incompatible with non-legacy PDU of extended advertising
+        if (adv_params.type != ble::advertising_type_t::CONNECTABLE_UNDIRECTED
+            && is_extended_advertising_supported()) {
             advertise_extended();
         }
     }


### PR DESCRIPTION
## Description
Cherry pick commit 31426f1 from master branch to fix same issue in mbed-os-5-15 branch

Fixes https://github.com/ARMmbed/mbed-os-example-ble/issues/312



----------------------------------------------------------------------------------------------------------------
## Pull request type

    [x] Patch update (Bug fix)



----------------------------------------------------------------------------------------------------------------
## Reviewers
@LDong-Arm - since this commit was your work originally, would you be so kind as to review my PR?