### PR TITLE
BLE: remove internal includes

### DIFF
--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -18,7 +18,6 @@
 #include <mbed.h>
 #include "ble/BLE.h"
 #include "ble/Gap.h"
-#include "gap/AdvertisingDataParser.h"
 #include "pretty_printer.h"
 
 /** This example demonstrates all the basic setup required


### PR DESCRIPTION
Fixes headers so that ble refactor can get through CI. These internal headers should never be included directly.