### PR TITLE
Update for mbed-os-6.2.1

### DIFF
--- a/BLE_BatteryLevel/mbed-os.lib
+++ b/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_Beacon/mbed-os.lib
+++ b/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_Button/mbed-os.lib
+++ b/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_GAPButton/mbed-os.lib
+++ b/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_GattClient/mbed-os.lib
+++ b/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_GattServer/mbed-os.lib
+++ b/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_HeartRate/mbed-os.lib
+++ b/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_LED/mbed-os.lib
+++ b/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_LEDBlinker/mbed-os.lib
+++ b/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_Privacy/mbed-os.lib
+++ b/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_SM/mbed-os.lib
+++ b/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/BLE_Thermometer/mbed-os.lib
+++ b/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_BatteryLevel/mbed-os.lib
+++ b/deprecated/BLE_BatteryLevel/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_Beacon/mbed-os.lib
+++ b/deprecated/BLE_Beacon/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_Button/mbed-os.lib
+++ b/deprecated/BLE_Button/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_GAP/mbed-os.lib
+++ b/deprecated/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_GAPButton/mbed-os.lib
+++ b/deprecated/BLE_GAPButton/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_GattClient/mbed-os.lib
+++ b/deprecated/BLE_GattClient/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_GattServer/mbed-os.lib
+++ b/deprecated/BLE_GattServer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_HeartRate/mbed-os.lib
+++ b/deprecated/BLE_HeartRate/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_LED/mbed-os.lib
+++ b/deprecated/BLE_LED/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_LEDBlinker/mbed-os.lib
+++ b/deprecated/BLE_LEDBlinker/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_Privacy/mbed-os.lib
+++ b/deprecated/BLE_Privacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_SM/mbed-os.lib
+++ b/deprecated/BLE_SM/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/deprecated/BLE_Thermometer/mbed-os.lib
+++ b/deprecated/BLE_Thermometer/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a2ada74770f043aff3e61e29d164a8e78274fcd4
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.2.1 release of mbed-os. 