### PR TITLE
CMake: Use renamed Mbed CMake targets component

### DIFF
--- a/BLE_LED/CMakeLists.txt
+++ b/BLE_LED/CMakeLists.txt
@@ -29,11 +29,12 @@ target_sources(${APP_TARGET}
 )
 
 target_link_libraries(${APP_TARGET}
-    mbed-os
-    mbed-os-events
-    mbed-os-ble
-    mbed-os-ble-cordio
-    mbed-os-ble-blue_nrg
+    PRIVATE
+        mbed-os
+        mbed-events
+        mbed-ble
+        mbed-ble-cordio
+        mbed-ble-blue_nrg
 )
 
 mbed_generate_bin_hex(${APP_TARGET})

--- a/BLE_LED/CMakeLists.txt
+++ b/BLE_LED/CMakeLists.txt
@@ -8,6 +8,8 @@ set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
 set(APP_TARGET BLE_LED)
 
+include(${MBED_ROOT}/tools/cmake/app.cmake)
+
 add_subdirectory(${MBED_ROOT})
 
 add_executable(${APP_TARGET})


### PR DESCRIPTION
They are now prefixed with "mbed-" instead of "mbed-os-"

Reviewers
@0xc0170 
@rajkan01 