### PR TITLE
Update BLE_SM filesystem support specific code

### DIFF
--- a/BLE_SM/mbed_app.json
+++ b/BLE_SM/mbed_app.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "filesystem-support": false
+    },
     "target_overrides": {
         "K64F": {
             "target.components_add": ["BlueNRG_MS"],

--- a/BLE_SM/source/main.cpp
+++ b/BLE_SM/source/main.cpp
@@ -156,15 +156,15 @@ private:
             printf("Error enabling privacy\r\n");
         }
 
-        Gap::peripheral_privacy_configuration_t configuration_p = {
+        ble::peripheral_privacy_configuration_t configuration_p = {
             /* use_non_resolvable_random_address */ false,
-            Gap::peripheral_privacy_configuration_t::REJECT_NON_RESOLVED_ADDRESS
+            ble::peripheral_privacy_configuration_t::REJECT_NON_RESOLVED_ADDRESS
         };
         _ble.gap().setPeripheralPrivacyConfiguration(&configuration_p);
 
-        Gap::central_privay_configuration_t configuration_c = {
+        ble::central_privacy_configuration_t configuration_c = {
             /* use_non_resolvable_random_address */ false,
-            Gap::CentralPrivacyConfiguration_t::RESOLVE_AND_FORWARD
+            ble::central_privacy_configuration_t::RESOLVE_AND_FORWARD
         };
         _ble.gap().setCentralPrivacyConfiguration(&configuration_c);
 

--- a/BLE_SM/source/main.cpp
+++ b/BLE_SM/source/main.cpp
@@ -182,9 +182,26 @@ private:
         /* print device address */
         print_mac_address();
 
+        /* With filesystem support enabled, privacy is configured above.
+           Setting up the privacy subsystem takes some time, during which most
+           GAP operations (advertising, scanning, connecting) are not possible.
+           The user application is notified by the BLE stack when privacy is ready
+           by the signal "Gap::EventHandler::onPrivacyEnabled". So in this case we 
+           defer the call to "SMDevice::start" to that callback handler. */
+#if !MBED_CONF_APP_FILESYSTEM_SUPPORT  
         /* start test in 500 ms */
         _event_queue.call_in(500, this, &SMDevice::start);
+#endif
+        
     };
+
+#if MBED_CONF_APP_FILESYSTEM_SUPPORT
+
+    virtual void onPrivacyEnabled() {
+        _event_queue.call(this, &SMDevice::start);
+    };
+    
+#endif
 
     /** Schedule processing of events from the BLE in the event queue. */
     void schedule_ble_events(BLE::OnEventsToProcessCallbackContext *context)


### PR DESCRIPTION
Fixes references to fully qualified types in the BLE stack that have since changed namespace. This issue would only occur when the user enabled filesystem support by adding:
```
"config": {
   "filesystem-support": true
}
```
To their `mbed_app.json`

Adds the `app.filesystem-support` configuration option (previously only mentioned in the example's code) to the `mbed_app.json` file.

Finally, this also adds an explanation for the topic discussed in #335 and shows how to use the new `Gap::EventHandler::onPrivacyEnabled` callback introduced in mbed-os-6.4.0

Perhaps this application configuration option can be added to CI builds to catch these simple errors?

Resolves #335 