### PR TITLE
CMake: Include the third party library

### DIFF
--- a/BLE_Advertising/CMakeLists.txt
+++ b/BLE_Advertising/CMakeLists.txt
@@ -11,6 +11,8 @@ include(${MBED_PATH}/tools/cmake/app.cmake)
 
 add_subdirectory(${MBED_PATH})
 
+add_subdirectory(mbed-os-ble-utils)
+
 add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
@@ -36,6 +38,7 @@ target_link_libraries(${APP_TARGET}
         mbed-ble
         mbed-ble-cordio
         mbed-ble-blue_nrg
+        mbed-os-ble-utils
 )
 
 mbed_set_post_build(${APP_TARGET})

--- a/BLE_Advertising/mbed-os-ble-utils.lib
+++ b/BLE_Advertising/mbed-os-ble-utils.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os-ble-utils/#fdb54c0dd8056aaa24e59256b86b237773d07e70
+https://github.com/ARMmbed/mbed-os-ble-utils/#ca5e78be227b8c5a7bc6fa11ba6d8325d286ffef


### PR DESCRIPTION
- Added the missing `mbed-os-ble-utils` directory in CMakeLists.txt which is normally created after `mbed deploy` command

@0xc0170 @pan- 