### PR TITLE
Update mbed-os to its development branch

### DIFF
--- a/BLE_Advertising/mbed-os.lib
+++ b/BLE_Advertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_GattClient_CharacteristicUpdates/mbed-os.lib
+++ b/BLE_GattClient_CharacteristicUpdates/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_GattClient_CharacteristicWrite/mbed-os.lib
+++ b/BLE_GattClient_CharacteristicWrite/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_GattServer_AddService/mbed-os.lib
+++ b/BLE_GattServer_AddService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_GattServer_CharacteristicUpdates/mbed-os.lib
+++ b/BLE_GattServer_CharacteristicUpdates/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_GattServer_CharacteristicWrite/mbed-os.lib
+++ b/BLE_GattServer_CharacteristicWrite/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/

--- a/BLE_SecurityAndPrivacy/mbed-os.lib
+++ b/BLE_SecurityAndPrivacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
Update the Mbed OS version pointed at by this example's development branch to the Mbed OS development branch. This ensures that the development branch will build using the latest mbed-os after a checkout and deploy.