### PR TITLE
Remove deprecated function from CMakeLists.txt

### DIFF
--- a/BLE_Advertising/CMakeLists.txt
+++ b/BLE_Advertising/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GAP/CMakeLists.txt
+++ b/BLE_GAP/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GattClient_CharacteristicUpdates/CMakeLists.txt
+++ b/BLE_GattClient_CharacteristicUpdates/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GattClient_CharacteristicWrite/CMakeLists.txt
+++ b/BLE_GattClient_CharacteristicWrite/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GattServer_AddService/CMakeLists.txt
+++ b/BLE_GattServer_AddService/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GattServer_CharacteristicUpdates/CMakeLists.txt
+++ b/BLE_GattServer_CharacteristicUpdates/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GattServer_CharacteristicWrite/CMakeLists.txt
+++ b/BLE_GattServer_CharacteristicWrite/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_GattServer_ExperimentalServices/CMakeLists.txt
+++ b/BLE_GattServer_ExperimentalServices/CMakeLists.txt
@@ -19,8 +19,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_sources(${APP_TARGET}

--- a/BLE_PeriodicAdvertising/CMakeLists.txt
+++ b/BLE_PeriodicAdvertising/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}

--- a/BLE_SecurityAndPrivacy/CMakeLists.txt
+++ b/BLE_SecurityAndPrivacy/CMakeLists.txt
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}


### PR DESCRIPTION
`mbed_set_mbed_target_linker_script` was removed from mbed-os.

This PR depends on ARMmbed/mbed-os#14199