### PR TITLE
Don't destroy set before it stops

### DIFF
--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -335,17 +335,19 @@ private:
         }
 
 #if BLE_FEATURE_EXTENDED_ADVERTISING
-        /* we were waiting for it to stop before destroying it and starting scanning */
-        ble_error_t error = _gap.destroyAdvertisingSet(_extended_adv_handle);
-        if (error) {
-            print_error(error, "Error caused by Gap::destroyAdvertisingSet");
+        if (event.getAdvHandle() == _extended_adv_handle) {
+            /* we were waiting for it to stop before destroying it and starting scanning */
+            ble_error_t error = _gap.destroyAdvertisingSet(_extended_adv_handle);
+            if (error) {
+                print_error(error, "Error caused by Gap::destroyAdvertisingSet");
+            }
+
+            _extended_adv_handle = ble::INVALID_ADVERTISING_HANDLE;
+
+            _is_in_scanning_phase = true;
+
+            _event_queue.call_in(delay, [this]{ scan(); });
         }
-
-        _extended_adv_handle = ble::INVALID_ADVERTISING_HANDLE;
-
-        _is_in_scanning_phase = true;
-
-        _event_queue.call_in(delay, [this]{ scan(); });
 #endif //BLE_FEATURE_EXTENDED_ADVERTISING
     }
 

--- a/BLE_GAP/source/main.cpp
+++ b/BLE_GAP/source/main.cpp
@@ -330,8 +330,23 @@ private:
 
     void onAdvertisingEnd(const ble::AdvertisingEndEvent &event) override
     {
-        if (event.isConnected()) {
-            printf("Stopped advertising early due to connection\r\n");
+        ble::advertising_handle_t adv_handle = event.getAdvHandle();
+        if (event.getStatus() == BLE_ERROR_UNSPECIFIED) {
+            printf("Error: Failed to stop advertising set %d\r\n", adv_handle);
+        } else {
+            printf("Stopped advertising set %d\r\n", adv_handle);
+
+            if (event.getStatus() == BLE_ERROR_TIMEOUT) {
+                printf("Stopped due to timeout\r\n");
+            } else if (event.getStatus() == BLE_ERROR_LIMIT_REACHED) {
+                printf("Stopped due to max number of adv events reached\r\n");
+            } else if (event.getStatus() == BLE_ERROR_NONE) {
+                if (event.isConnected()) {
+                    printf("Stopped early due to connection\r\n");
+                } else {
+                    printf("Stopped due to user request\r\n");
+                }
+            }
         }
 
 #if BLE_FEATURE_EXTENDED_ADVERTISING
@@ -503,6 +518,8 @@ private:
     void end_advertising_mode()
     {
         print_advertising_performance();
+
+        printf("Requesting stop advertising.\r\n");
 
         _gap.stopAdvertising(ble::LEGACY_ADVERTISING_HANDLE);
 


### PR DESCRIPTION
Set destroyed too early. We need to wait until it stops. The change is that I moved the block that destroys the set and continues the demo to the advertising end event (only for extended advertising).