### PR TITLE
CMake: Make applications the top level CMake projects

### DIFF
--- a/BLE_Advertising/CMakeLists.txt
+++ b/BLE_Advertising/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_Advertising)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GAP/CMakeLists.txt
+++ b/BLE_GAP/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_GAP)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GattClient_CharacteristicUpdates/CMakeLists.txt
+++ b/BLE_GattClient_CharacteristicUpdates/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_GattClient_CharacteristicUpdates)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GattClient_CharacteristicWrite/CMakeLists.txt
+++ b/BLE_GattClient_CharacteristicWrite/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_GattClient_CharacteristicWrite)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GattServer_AddService/CMakeLists.txt
+++ b/BLE_GattServer_AddService/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_GattServer_AddService)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GattServer_CharacteristicUpdates/CMakeLists.txt
+++ b/BLE_GattServer_CharacteristicUpdates/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_GattServer_CharacteristicUpdates)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GattServer_CharacteristicWrite/CMakeLists.txt
+++ b/BLE_GattServer_CharacteristicWrite/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_GattServer_CharacteristicWrite)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_GattServer_ExperimentalServices/CMakeLists.txt
+++ b/BLE_GattServer_ExperimentalServices/CMakeLists.txt
@@ -9,6 +9,8 @@ set(APP_TARGET BLE_GattServer_ExperimentalServices)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
@@ -16,8 +18,6 @@ add_subdirectory(mbed-os-experimental-ble-services/services/CurrentTime)
 add_subdirectory(mbed-os-experimental-ble-services/services/LinkLoss)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_sources(${APP_TARGET}
     PRIVATE

--- a/BLE_PeriodicAdvertising/CMakeLists.txt
+++ b/BLE_PeriodicAdvertising/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_PeriodicAdvertising)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_SecurityAndPrivacy/CMakeLists.txt
+++ b/BLE_SecurityAndPrivacy/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET BLE_SecurityAndPrivacy)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_subdirectory(mbed-os-ble-utils)
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE

--- a/BLE_SupportedFeatures/CMakeLists.txt
+++ b/BLE_SupportedFeatures/CMakeLists.txt
@@ -9,11 +9,11 @@ set(APP_TARGET BLE_SupportedFeatures)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PRIVATE


### PR DESCRIPTION
So CMake can work correctly we need to define our project before we add
dependencies, otherwise the project we depend on will be registered as
the current project.