### PR TITLE
Update for mbed-os-6.15.0

### DIFF
--- a/BLE_Advertising/mbed-os.lib
+++ b/BLE_Advertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GattClient_CharacteristicUpdates/mbed-os.lib
+++ b/BLE_GattClient_CharacteristicUpdates/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GattClient_CharacteristicWrite/mbed-os.lib
+++ b/BLE_GattClient_CharacteristicWrite/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GattServer_AddService/mbed-os.lib
+++ b/BLE_GattServer_AddService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GattServer_CharacteristicUpdates/mbed-os.lib
+++ b/BLE_GattServer_CharacteristicUpdates/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GattServer_CharacteristicWrite/mbed-os.lib
+++ b/BLE_GattServer_CharacteristicWrite/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_GattServer_ExperimentalServices/mbed-os.lib
+++ b/BLE_GattServer_ExperimentalServices/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_SecurityAndPrivacy/mbed-os.lib
+++ b/BLE_SecurityAndPrivacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938

--- a/BLE_SupportedFeatures/mbed-os.lib
+++ b/BLE_SupportedFeatures/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3377f083b3a6bd7a1b45ed2cea5cf083b9007527
+https://github.com/ARMmbed/mbed-os/#4cfbea43cabe86bc3ed7a5287cd464be7a218938


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.15.0 release of mbed-os. 