### PR TITLE
Update for mbed-os-6.16.0

### DIFF
--- a/BLE_Advertising/mbed-os.lib
+++ b/BLE_Advertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GAP/mbed-os.lib
+++ b/BLE_GAP/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GattClient_CharacteristicUpdates/mbed-os.lib
+++ b/BLE_GattClient_CharacteristicUpdates/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GattClient_CharacteristicWrite/mbed-os.lib
+++ b/BLE_GattClient_CharacteristicWrite/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GattServer_AddService/mbed-os.lib
+++ b/BLE_GattServer_AddService/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GattServer_CharacteristicUpdates/mbed-os.lib
+++ b/BLE_GattServer_CharacteristicUpdates/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GattServer_CharacteristicWrite/mbed-os.lib
+++ b/BLE_GattServer_CharacteristicWrite/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_GattServer_ExperimentalServices/mbed-os.lib
+++ b/BLE_GattServer_ExperimentalServices/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_PeriodicAdvertising/mbed-os.lib
+++ b/BLE_PeriodicAdvertising/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_SecurityAndPrivacy/mbed-os.lib
+++ b/BLE_SecurityAndPrivacy/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f

--- a/BLE_SupportedFeatures/mbed-os.lib
+++ b/BLE_SupportedFeatures/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#2eb06e76208588afc6cb7580a8dd64c5429a10ce
+https://github.com/ARMmbed/mbed-os/#54e8693ef4ff7e025018094f290a1d5cf380941f


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.16.0 release of mbed-os. 